### PR TITLE
fix: update link for budget creation to point to the correct URL

### DIFF
--- a/src/components/SideBar/side-bar.tsx
+++ b/src/components/SideBar/side-bar.tsx
@@ -602,7 +602,7 @@ function SidebarContent({ collapsed }: { collapsed: boolean }) {
         <li>
           <ItemTooltip label="Fazer orçamento">
             <a
-              href="https://piva-orcamentos-01.vercel.app/"
+              href="https://piva-orcamentos-pdf.vercel.app/"
               target="_blank"
               rel="noopener noreferrer"
               className={`flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 ${


### PR DESCRIPTION
This pull request makes a small update to the sidebar's "Fazer orçamento" link, changing its destination URL to a new address. This ensures users are directed to the correct budgeting tool.

- Updated the "Fazer orçamento" sidebar link to point to `https://piva-orcamentos-pdf.vercel.app/` instead of the old URL.